### PR TITLE
💥 breaking convert from poetry to uv

### DIFF
--- a/.github/workflows/👷Flow.yml
+++ b/.github/workflows/👷Flow.yml
@@ -9,19 +9,23 @@ on:
 
 jobs:
   lint:
-    uses: mraniki/coding_toolset/.github/workflows/🦺Lint.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/🦺Lint.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVLint.yml@main
     secrets: inherit
   test:
     needs: [lint]
-    uses: mraniki/coding_toolset/.github/workflows/🧪Test.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/🧪Test.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVTest.yml@main
     secrets: inherit
   build:
     needs: [lint]
-    uses: mraniki/coding_toolset/.github/workflows/🐍Build.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/🐍Build.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVBuild.yml@main
     secrets: inherit
   release:
     needs: [build, test]
-    uses: mraniki/coding_toolset/.github/workflows/📦Release.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/📦Release.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVRelease.yml@main # Use UV-specific release workflow
     secrets: inherit
 
  

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -4,11 +4,15 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+    # uv is not directly supported in tools, install via pip below
+    # uv: "latest"
   jobs:
+    # Install uv after the environment is created
     post_create_environment:
-      - python -m pip install poetry
+      - pip install uv
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH python -m poetry install --with docs
+      # Install the package with docs extras using uv
+      - uv pip install -e '.[docs]'
 
 sphinx:
   configuration: docs/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,38 +1,64 @@
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 
-[tool.poetry]
+[project]
 name = "findmyorder"
 version = "2.2.11"
 description = "A python package to identify and parse order for trade execution."
-authors = ["mraniki <8766259+mraniki@users.noreply.github.com>"]
-license = "MIT License"
+authors = [
+  { name = "mraniki", email = "8766259+mraniki@users.noreply.github.com" },
+]
+license = "MIT"
 readme = "README.md"
 keywords = ["trading", "order", "trade","buy","sell"]
-packages = [
-    {include = "findmyorder"}
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+  "dynaconf>=3.2.0",
+  "loguru>=0.6.0",
+  "pyparsing>=3.0.9",
 ]
 
 
-[tool.poetry.urls]
+[project.urls]
+"Homepage" = "https://github.com/mraniki/findmyorder"
 "Changelog" =  "https://github.com/mraniki/findmyorder/blob/dev/CHANGELOG.rst"
 "Support" =  "https://github.com/mraniki/findmyorder/discussions"
 "Issues" =  "https://github.com/mraniki/findmyorder/issues"
 
 
-[tool.poetry.dependencies]
-python = "^3.10"
-dynaconf = ">=3.2.0"
-loguru = ">=0.6.0"
-pyparsing = "^3.0.9"
+[project.optional-dependencies]
+dev = [
+  "python-semantic-release>=8.0.8",
+  "ruff~=0.7",
+  "pre-commit~=3.3",
+]
+test = [
+  "pytest~=8.0",
+  "pytest-cov~=5.0",
+  "pytest-asyncio~=0.24",
+  "pytest-mock~=3.11",
+  "pytest-loguru~=0.4",
+]
+docs = [
+  "sphinx==7.4.7",
+  "pydata-sphinx-theme~=0.14",
+  "sphinx-hoverxref~=1.3",
+  "sphinx_copybutton==0.5.2",
+  "myst_parser~=4.0",
+  "sphinx_design~=0.6",
+]
 
+[tool.setuptools]
+packages = ["findmyorder"]
 
-[tool.poetry.group.dev.dependencies]
-python-semantic-release = ">=8.0.8"
-ruff = "^0.7.0"
-pre-commit = "^3.3.1"
 
 [tool.ruff]
 exclude = [
@@ -42,17 +68,15 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
-  "E",  # pycodestyle
-  "F",  # pyflakes
-  "I",  # isort
+  "E",
+  "F",
+  "I",
   "W"
 ]
 
-#ignore = ["E401","F401","F811"]
 fixable = ["ALL"]
 
 [tool.ruff.format]
-# Like Black, use double quotes for strings.
 quote-style = "double"
 
 [tool.pylint.exceptions]
@@ -62,74 +86,6 @@ overgeneral-exceptions = [
     "builtins.RuntimeError",
 ]
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-[tool.poetry.group.test.dependencies]
-pytest = "^8.0.0"
-pytest-cov = "^5.0.0"
-pytest-asyncio = "^0.24.0"
-pytest-mock = "^3.11.1"
-pytest-loguru = "^0.4.0"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-sphinx = "7.4.7"
-pydata-sphinx-theme = "^0.14.0"
-sphinx-hoverxref = "^1.3.0"
-sphinx-notfound-page = "^1.0.0rc1"
-sphinx_copybutton = "0.5.2"
-myst_parser = "^4.0.0"
-sphinx_design = "^0.6.0"
 
 [tool.pytest.ini_options]
 pythonpath = "."
@@ -158,10 +114,9 @@ skips = ["B101","B104"]
 [tool.semantic_release]
 upload_to_vcs_release = true
 version_variables = ["findmyorder/__init__.py:__version__"]
-build_command = "pip install poetry && poetry build"
 commit_parser = "emoji"
 version_toml = [
-   "pyproject.toml:tool.poetry.version",
+   "pyproject.toml:project.version",
    ]
 
 [tool.semantic_release.commit_parser_options]
@@ -204,7 +159,6 @@ patch_tags = ["fix","bump","Update",
 ]
 
 [tool.semantic_release.changelog]
-# template_dir = "templates"
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
 


### PR DESCRIPTION
## Summary by Sourcery

Migrate the project from Poetry to Setuptools and UV.

Build:
- Configure `pyproject.toml` to use Setuptools as the build backend.
- Adopt the standard `[project]` table in `pyproject.toml` for metadata and dependencies, replacing the `[tool.poetry]` table.
- Update Semantic Release configuration to reflect the build system change.
- Remove the explicit build command from Semantic Release configuration, relying on standard mechanisms.
- Utilize UV for dependency management within development and CI environments (implied by related changes).

CI:
- Update CI workflows to use UV for installing dependencies (inferred from related changes).

Documentation:
- Update ReadTheDocs configuration to use UV for installing documentation dependencies.